### PR TITLE
Alex601t issue26

### DIFF
--- a/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudio/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -85,11 +85,12 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     }
 
     var duration: TimeInterval {
-        if let timeRange = currentItem?.loadedTimeRanges.first?.timeRangeValue {
-            let seconds = timeRange.duration.seconds
-            if !seconds.isNaN {
-                return seconds
-            }
+        if let seconds = currentItem?.duration.seconds, !seconds.isNaN {
+            return seconds
+        }
+        else if let seconds = currentItem?.loadedTimeRanges.first?.timeRangeValue.duration.seconds,
+            !seconds.isNaN {
+            return seconds
         }
         return 0.0
     }

--- a/SwiftAudio/Classes/Observer/AVPlayerItemObserver.swift
+++ b/SwiftAudio/Classes/Observer/AVPlayerItemObserver.swift
@@ -27,6 +27,7 @@ class AVPlayerItemObserver: NSObject {
     
     private struct AVPlayerItemKeyPath {
         static let duration = #keyPath(AVPlayerItem.duration)
+        static let loadedTimeRanges = #keyPath(AVPlayerItem.loadedTimeRanges)
     }
     
     var isObserving: Bool = false
@@ -53,11 +54,13 @@ class AVPlayerItemObserver: NSObject {
             self.isObserving = true
             self.observingItem = item
             item.addObserver(self, forKeyPath: AVPlayerItemKeyPath.duration, options: [.new], context: &AVPlayerItemObserver.context)
+            item.addObserver(self, forKeyPath: AVPlayerItemKeyPath.loadedTimeRanges, options: [.new], context: &AVPlayerItemObserver.context)
         }
     }
     
     func stopObservingCurrentItem() {
         observingItem?.removeObserver(self, forKeyPath: AVPlayerItemKeyPath.duration, context: &AVPlayerItemObserver.context)
+        observingItem?.removeObserver(self, forKeyPath: AVPlayerItemKeyPath.loadedTimeRanges, context: &AVPlayerItemObserver.context)
         self.isObserving = false
         self.observingItem = nil
     }
@@ -73,8 +76,12 @@ class AVPlayerItemObserver: NSObject {
             if let duration = change?[.newKey] as? CMTime {
                 self.delegate?.item(didUpdateDuration: duration.seconds)
             }
-        default:
-            break
+        
+        case AVPlayerItemKeyPath.loadedTimeRanges:
+            if let ranges = change?[.newKey] as? [NSValue], let duration = ranges.first?.timeRangeValue.duration {
+                self.delegate?.item(didUpdateDuration: duration.seconds)
+            }
+        default: break
             
         }
     }


### PR DESCRIPTION
Hey! Added a couple of fixes to your branch

- Adds observing of the `loadedTimeRanges` of an item
- Use the `currentItem.duration.seconds` if it is loaded, use the loadedTimeRanges otherwise

Tests should now pass, and delegate the AVWrapperDelegate should get notified when the duration is loaded, also when loadedTimeRanges is populated.